### PR TITLE
Adds Systemd Support

### DIFF
--- a/docker-spotter.service
+++ b/docker-spotter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Docker Spotter
+After=docker.socket
+Requires=docker.socket
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/sysconfig/docker-spotter
+ExecStart=/usr/bin/docker-spotter $OPTIONS
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Previously, docker-spotter was unable to be managed by systemd.
This patch provides users the ability to manage the service using
systemd.