### PR TITLE
Fix remaining JSONMessage upstream

### DIFF
--- a/spotter.go
+++ b/spotter.go
@@ -18,7 +18,6 @@ import (
 	"text/template"
 
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/dotcloud/docker/utils"
 )
 
 const APIVERSION = "1.8"
@@ -40,7 +39,7 @@ type Container struct {
 	Name   string
 	ID     string
 	Config ContainerConfig
-	Event  utils.JSONMessage
+	Event  jsonmessage.JSONMessage
 }
 
 // id, event, command


### PR DESCRIPTION
`github.com/dotcloud/docker/utils` doesn't exist anymore, and changing `utils` to `jsonmessage` allows the package to build. Tests are passing.